### PR TITLE
Mostly finished reactor unit (without stirring mechanism)

### DIFF
--- a/hardware/urls.j2
+++ b/hardware/urls.j2
@@ -1,4 +1,4 @@
 {#% set repo = "https://raw.githubusercontent.com/FourThievesVinegar/microlab-parts/" %#}
 {% set repo = "https://raw.githubusercontent.com/openvmp/forked-FourThievesVinegar-microlab-parts/" %}
-{% set revision = "4f80a54aca830f841af90885d3d75307d7337916" %}
+{% set revision = "3d1371d9f2ba293ec7beb92ac84288c4f80e06ac" %}
 {% set url_prefix = repo + revision %}

--- a/hardware/v6/microlab.assy
+++ b/hardware/v6/microlab.assy
@@ -7,11 +7,6 @@ links:
   - assembly: cooling-unit
     name: cooling-unit
     location: [[300, -100, 165], [0, 1, 0], 180]
-  - assembly: reactor-unit-reactor-stand
-    name: reactor-unit-reactor-stand
+  - assembly: reactor-unit
+    name: reactor-unit
     location: [[300, 100, 0], [1, 0, 0], 0]
-  - assembly: reactor-unit-pumps-box
-    name: reactor-unit-pumps-box
-    # TODO: Attention, minor vertical discrepancy 
-    # with -reactor-stand mounts
-    location: [[304, 196, 132.5], [1, 0, 0], 0]

--- a/hardware/v6/partcad.yaml
+++ b/hardware/v6/partcad.yaml
@@ -257,9 +257,8 @@ parts:
   stand-jar-flange:
     desc: Jar flange holding reactor core on stand
     type: step
-    # fileFrom: url
-    # fileUrl: {{ url }}/reactor-stand/reactor-stand-jar-flange.v0.1.step
-    path: reactor-stand-jar-flange.v0.1.step
+    fileFrom: url
+    fileUrl: {{ url }}/reactor-stand/reactor-stand-jar-flange.v0.1.step
     implements:
       "m80-opening":
         base: [[0, 1.5, 0], [1, 0, 0], 90]
@@ -318,6 +317,8 @@ parts:
       "m74-opening":
         lid-place: [[0, 0, 2], [1, 0, 0], 180]
       # "m60-jar-threaded-lid":
+      # TODO: potential bug - if above line is uncommented,
+      # we need to clarify this later, but port is used
         bottom: [[0, 0, 5], [1, 0, 0], 0]
   reactor-core-inner-jar:
     desc: Smaller/inner jar of Reactor core
@@ -335,6 +336,8 @@ parts:
       "m60-opening":
         lid-place: [[0, 0, 2], [1, 0, 0], 180]
       # "m60-jar-threaded-lid":
+      # TODO: potential bug - if above line is uncommented,
+      # we need to clarify this later, but port is used
         bottom: [[0, 0, 5], [1, 0, 0], 0]
   reactor-core-stir-rod-mount:
     desc: Mount for stirring rod

--- a/hardware/v6/partcad.yaml
+++ b/hardware/v6/partcad.yaml
@@ -18,55 +18,59 @@ docs:
 {% from 'urls.j2' import url_prefix %}
 {% set url = url_prefix + '/v6' %}
 
+{% set sizes = [46, 60, 74, 80] %} 
 sketches:
-  m26:
+  {% for size in sizes %}
+  m{{ size }}:
     type: basic
-    circle: 13 # 13 mm radius equals to 26 mm diameter
-  m74:
-    type: basic
-    circle: 37 # 37 mm radius equals to 74 mm diameter
+    circle: {{ size / 2.0 }}  # radius
+  {% endfor %}
   ring-5-3:
     desc: Ring with 5 mm outer radius and 3 mm inner radius
     type: basic
     circle: 5
     inner:
       circle: 3
-  
+
 interfaces:
-  m74:
-    desc: Abstract 74 mm circular interface
+  {% for size in sizes %}
+  m{{ size }}:
+    desc: Abstract {{ size }} mm circular interface
     abstract: True
     ports:
-      m74:
-        location: [[0, 0, 0], [0, 0, 1], 0] # redandant, for demonstration
-        sketch: m74
-    parameters:
-      turnZ:
-        min: 0
-        max: 360
-        default: 0
-      moveX: {}  # Hotizontal offset for openings of different sizes
-      moveY: {}  # Hotizontal offset for openings of different sizes
-      moveZ: {}  # Offset along the alignment axis  m74-jar-mouth:
-  m74-opening:
-    desc: Abstract 74 mm circular opening
+      m{{ size }}:
+        location: [[0, 0, 0], [0, 0, 1], 0] # redundant, for demonstration
+        sketch: m{{ size }}
+  m{{ size }}-opening:
+    desc: Abstract {{ size }} mm circular opening
     inherits:
-      m74: opening
-  m74-jar-mouth:
-    desc: Jar mouth (inner opening) with 74 mm diameter
+      m{{ size }}: opening
+  m{{ size }}-jar-mouth:
+    desc: Jar mouth (inner opening) with {{ size }} mm diameter
     inherits: 
-      m74-opening: jar-mouth
-  m74-shaft:
-    desc: Abstract 74 mm shaft
+      m{{ size }}-opening: jar-mouth
+  m{{ size }}-jar-threaded-lid:
+    desc: Threaded jar lid with {{ size }} mm inner diameter
+    inherits: 
+      m{{ size }}-opening: jar-threaded-lid
+  m{{ size }}-shaft:
+    desc: Abstract {{ size }} mm shaft
     inherits:
-      m74: shaft
+      m{{ size }}: shaft
     mates:
-      - m74-opening
-  m74-jar-closing:
+      - m{{ size }}-opening
+  m{{ size }}-jar-closing:
     inherits: 
-      m74-shaft: jar-closing
+      m{{ size }}-shaft: jar-closing
     mates:
-      - m74-jar-mouth  
+      - m{{ size }}-jar-mouth  
+  m{{ size }}-jar-threaded-top:
+    desc: Threaded top of a cylindric jar with {{ size }} mm outer diameter
+    inherits: 
+      m{{ size }}-shaft: jar-threaded-top
+    mates:
+      - m{{ size }}-jar-threaded-lid
+  {% endfor %}
 
 parts:
   # Control Unit
@@ -250,7 +254,102 @@ parts:
         eye-back-lower: [[-113.5, 9, -70], [1, 1, 0], 180]
         eye-front-1: [[-113.5, 145.5, 71.5], [1, 1, 0], 180]
         eye-front-2: [[-113.5, 174, 71.5], [1, 1, 0], 180]
+  stand-jar-flange:
+    desc: Jar flange holding reactor core on stand
+    type: step
+    # fileFrom: url
+    # fileUrl: {{ url }}/reactor-stand/reactor-stand-jar-flange.v0.1.step
+    path: reactor-stand-jar-flange.v0.1.step
+    implements:
+      "m80-opening":
+        base: [[0, 1.5, 0], [1, 0, 0], 90]
 
+  # Reactor core
+  reactor-core-manifold-core:
+    desc: Reactor core manifold - core part
+    type: step
+    fileFrom: url
+    fileUrl: {{ url }}/reactor-manifold/reactor-manifold-core-v0.1.step
+    implements:
+      # TODO: a different interface most probably
+      "m60-jar-closing":
+        base: [[0, 0, -54], [1, 0, 0], 180]
+      # TODO: check this and next interface, do the holes have thread
+      "/pub/std/metric/m:m3-hole-10":
+        side-back: [[0, 21.5, -12], [1, 0, 0], -90]
+        side-left: [[-18.6, -10.7, -12], [-0.5, 0.866, 0], -90]
+        side-right: [[18.6, -10.7, -12], [0.5, 0.866, 0], 90]
+      # "/pub/std/metric/m:m3-hole-20":
+        top-back: [[0, 13, 0], [1, 0, 0], 180]
+        top-left: [[-11.25, -6.5, 0], [1, 0, 0], 180]
+        top-right: [[11.25, -6.5, 0], [1, 0, 0], 180]
+  reactor-core-manifold-lid:
+    desc: Reactor core manifold - lid part
+    type: step
+    fileFrom: url
+    fileUrl: {{ url }}/reactor-manifold/reactor-manifold-lid-v0.1.step
+    implements:
+      "m74-jar-closing":
+        top: [[0, 0, 0], [1, 0, 0], 0]
+      "/pub/std/metric/m:m3-thru":
+        back-inner: [[-21.5, 0, 12], [0.7071, 0, 0.7071], 180]
+        # TODO: add other 2 inner interfaces when needed
+        back-outer: [[-26.5, 0, 12], [0, 1, 0], 90]
+        left-outer: [[13.25, 23, 12], [-0.866, 0.5, 0], -90]
+        right-outer: [[13.25, -23, 12], [0.866, 0.5, 0], -90]
+  reactor-core-outer-jar:
+    desc: Bigger/outer jar of Reactor core
+    type: cadquery
+    path: parts/mason-jar-32oz-wide-mouth.py
+    implements:
+      "m74-jar-threaded-top":
+        top: [[0, 0, 165], [1, 0, 0], 0]
+      # TODO: most probably this should be a new "shimmed" interface
+      # together with 2 flanges
+      "m80-shaft":
+        neck-lower: [[0, 0, 140], [0, 0, 1], 180]
+        neck-upper: [[0, 0, 150.5], [0, 0, 1], 180]  
+  reactor-core-outer-jar-band:
+    desc: Band for bigger/outer jar of Reactor core
+    type: cadquery
+    path: parts/mason-jar-band-wide-mouth.py
+    implements:
+      # TODO: a different interface most probably
+      "m74-opening":
+        lid-place: [[0, 0, 2], [1, 0, 0], 180]
+      # "m60-jar-threaded-lid":
+        bottom: [[0, 0, 5], [1, 0, 0], 0]
+  reactor-core-inner-jar:
+    desc: Smaller/inner jar of Reactor core
+    type: cadquery
+    path: parts/mason-jar-6oz-regular-mouth.py
+    implements:
+      "m60-jar-threaded-top":
+        top: [[0, 0, 81], [1, 0, 0], 0]
+  reactor-core-inner-jar-band:
+    desc: Band for smaller/inner jar of Reactor core
+    type: cadquery
+    path: parts/mason-jar-band-regular-mouth.py
+    implements:
+      # TODO: a different interface most probably
+      "m60-opening":
+        lid-place: [[0, 0, 2], [1, 0, 0], 180]
+      # "m60-jar-threaded-lid":
+        bottom: [[0, 0, 5], [1, 0, 0], 0]
+  reactor-core-stir-rod-mount:
+    desc: Mount for stirring rod
+    type: step
+    fileFrom: url
+    fileUrl: {{ url }}/reactor-manifold/stirring-mount-v0.1.step
+    implements:
+      "/pub/std/metric/m:m3-thru":
+        upper-back: [[67.85, 116.85, 469], [1, 0, 0], 180]
+        upper-left: [[86.7, 128, 469], [1, 0, 0], 180]
+        upper-right: [[86.95, 106.15, 469], [1, 0, 0], 180]
+        bottom-back: [[67.85, 116.85, 459], [1, 0, 0], 0]
+        bottom-left: [[86.7, 128, 459], [1, 0, 0], 0]
+        bottom-right: [[86.95, 106.15, 459], [1, 0, 0], 0]
+                
   # Temperature Exchange Units
   cold-unit-jar:
     desc: Jar for cooling unit
@@ -313,12 +412,24 @@ assemblies:
     parameters:
       screw_type:
         type: string
-        desc: Type of the screws attaching lid to the control box
+        desc: Type of the screws attaching lid to the pumps box
         enum: [raisedcountersunkovalhead-iso7047, raisedcheesehead-iso7045]
         default: raisedcountersunkovalhead-iso7047
   reactor-unit-reactor-stand:
     type: assy
     path: reactor-unit-reactor-stand.assy
+    implements:
+      "m80-opening":
+        core-holder: [[98, 22, 155.5], [1, 0, 0], 0]
+  reactor-unit-reactor-core:
+    type: assy
+    path: reactor-unit-reactor-core.assy
+    implements:
+      "m80-shaft":
+        stand-neck: [[0, 0, -29], [1, 0, 0], 0]
+  reactor-unit:
+    type: assy
+    path: reactor-unit.assy
   heating-unit:
     type: assy
     path: heating-unit.assy

--- a/hardware/v6/partcad.yaml
+++ b/hardware/v6/partcad.yaml
@@ -296,6 +296,7 @@ parts:
         side-back: [[0, 21.5, -12], [1, 0, 0], -90]
         side-left: [[-18.6, -10.7, -12], [-0.5, 0.866, 0], -90]
         side-right: [[18.6, -10.7, -12], [0.5, 0.866, 0], 90]
+      # TODO: fix this with more careful connections handling
       # "/pub/std/metric/m:m3-hole-20":
         top-back: [[0, 13, 0], [1, 0, 0], 180]
         top-left: [[-11.25, -6.5, 0], [1, 0, 0], 180]

--- a/hardware/v6/partcad.yaml
+++ b/hardware/v6/partcad.yaml
@@ -41,35 +41,53 @@ interfaces:
       m{{ size }}:
         location: [[0, 0, 0], [0, 0, 1], 0] # redundant, for demonstration
         sketch: m{{ size }}
+
   m{{ size }}-opening:
     desc: Abstract {{ size }} mm circular opening
     inherits:
       m{{ size }}: opening
+
   m{{ size }}-jar-mouth:
     desc: Jar mouth (inner opening) with {{ size }} mm diameter
     inherits: 
       m{{ size }}-opening: jar-mouth
+
+  m{{ size }}-threaded-opening:
+    # TODO: desc: ...
+    ports:
+      m{{ size }}-threaded:
+        location: [[0, 0, 0], [0, 0, 1], 0] # redundant, for demonstration
+        sketch: m{{ size - 1}}
+
   m{{ size }}-jar-threaded-lid:
-    desc: Threaded jar lid with {{ size }} mm inner diameter
+    # TODO: desc: ...
     inherits: 
-      m{{ size }}-opening: jar-threaded-lid
+      m{{ size }}-threaded-opening: jar-lid
+  
   m{{ size }}-shaft:
     desc: Abstract {{ size }} mm shaft
     inherits:
       m{{ size }}: shaft
     mates:
       - m{{ size }}-opening
+  
   m{{ size }}-jar-closing:
     inherits: 
       m{{ size }}-shaft: jar-closing
     mates:
       - m{{ size }}-jar-mouth  
+  
+  m{{ size }}-threaded-shaft:
+    desc: Threaded shaft with {{ size }} mm outer diameter
+    inherits:
+      m{{ size }}-shaft: threaded
+    mates:
+      - m{{ size }}-threaded-opening
+  
   m{{ size }}-jar-threaded-top:
     desc: Threaded top of a cylindric jar with {{ size }} mm outer diameter
     inherits: 
-      m{{ size }}-shaft: jar-threaded-top
-    mates:
-      - m{{ size }}-jar-threaded-lid
+      m{{ size }}-threaded-shaft: jar-top
   {% endfor %}
 
 parts:
@@ -301,8 +319,7 @@ parts:
     type: cadquery
     path: parts/mason-jar-32oz-wide-mouth.py
     implements:
-      "m74-jar-threaded-top":
-        top: [[0, 0, 165], [1, 0, 0], 0]
+      "m74-jar-threaded-top": [[0, 0, 165], [1, 0, 0], 180]
       # TODO: most probably this should be a new "shimmed" interface
       # together with 2 flanges
       "m80-shaft":
@@ -316,10 +333,7 @@ parts:
       # TODO: a different interface most probably
       "m74-opening":
         lid-place: [[0, 0, 2], [1, 0, 0], 180]
-      # "m60-jar-threaded-lid":
-      # TODO: potential bug - if above line is uncommented,
-      # we need to clarify this later, but port is used
-        bottom: [[0, 0, 5], [1, 0, 0], 0]
+      "m74-jar-threaded-lid": [[0, 0, 5], [1, 0, 0], 180]
   reactor-core-inner-jar:
     desc: Smaller/inner jar of Reactor core
     type: cadquery
@@ -335,10 +349,7 @@ parts:
       # TODO: a different interface most probably
       "m60-opening":
         lid-place: [[0, 0, 2], [1, 0, 0], 180]
-      # "m60-jar-threaded-lid":
-      # TODO: potential bug - if above line is uncommented,
-      # we need to clarify this later, but port is used
-        bottom: [[0, 0, 5], [1, 0, 0], 0]
+      "m60-jar-threaded-lid": [[0, 0, 5], [1, 0, 0], 0]
   reactor-core-stir-rod-mount:
     desc: Mount for stirring rod
     type: step

--- a/hardware/v6/parts/mason-jar-6oz-regular-mouth.py
+++ b/hardware/v6/parts/mason-jar-6oz-regular-mouth.py
@@ -1,0 +1,60 @@
+import cadquery as cq
+
+# Parameters for the Mason jar with a realistic shape
+jar_diameter_middle = 60.0
+jar_diameter_bottom = 55.0 
+jar_height = 81.0  # mm, total height
+jar_thread_height = 71.0
+jar_bottom_height = 5.0
+jar_wall_thickness = 1.5  # mm
+lid_thread_diameter = 64.0  # mm, outer thread diameter
+lid_thread_height = 10.0  # mm
+
+# ----------------------------
+# 1. Create Outer Jar Shape
+# ----------------------------
+outer_jar_profile = (
+    cq.Workplane("XZ")
+    .moveTo(jar_diameter_bottom / 2, 0)  # Start at the base
+    .spline(
+        listOfXYTuple=[
+            (jar_diameter_bottom / 2, 0), 
+            (jar_diameter_middle / 2, jar_bottom_height)
+        ], 
+        tangents=[(0.5, 0.5), (0, 1)]
+    )
+    .lineTo(jar_diameter_middle / 2, jar_height)
+    .lineTo(0, jar_height)  # Close the top
+    .lineTo(0, 0)  # Close back to base
+    .close()  # Ensure the profile is closed
+    .revolve()  # Revolve around the Z-axis
+)
+
+# ----------------------------
+# 2. Create Inner Jar Shape (for hollowing)
+# ----------------------------
+inner_jar_profile = (
+    cq.Workplane("XZ")
+    .moveTo(jar_diameter_bottom / 2 - jar_wall_thickness, jar_wall_thickness)
+    .spline(
+        listOfXYTuple=[
+            (jar_diameter_bottom / 2 - jar_wall_thickness, jar_wall_thickness), 
+            (jar_diameter_middle / 2 - jar_wall_thickness, jar_bottom_height)
+        ], 
+        tangents=[(0.5, 0.5), (0, 1)]
+    )
+    .lineTo(jar_diameter_middle / 2 - jar_wall_thickness, jar_height)
+    .lineTo(0, jar_height)  # Close the top
+    .lineTo(0, 0)  # Close back to base
+    .close()  # Ensure the profile is closed
+    .revolve()  # Revolve around the Z-axis
+ )
+
+# ----------------------------
+# 3. Subtract Inner Profile from Outer Profile
+# ----------------------------
+mason_jar = outer_jar_profile.cut(inner_jar_profile)
+
+# TODO: add thread maybe later (standard: 86-400 or 89-400)
+
+show_object(mason_jar)

--- a/hardware/v6/parts/mason-jar-band-regular-mouth.py
+++ b/hardware/v6/parts/mason-jar-band-regular-mouth.py
@@ -1,14 +1,13 @@
 import cadquery as cq
 
-outer_diameter = 84.0
-inner_diameter = 65.0
-mason_thread_od = 79
-thread_pitch = 6.5
-thread_h = thread_pitch*2.5
+outer_diameter = 67.0
+inner_diameter = 52.0
+mason_thread_od = 61.0
+thread_pitch = 3.5
+thread_h = thread_pitch * 2.5
 lid_h = thread_h + 2
-wall_thickness = 2
+wall_thickness = 1
 thread_contour_diam = 2.1
-thread_contour_h = 2.2
 
 thread_r = mason_thread_od/2 + thread_contour_diam 
 

--- a/hardware/v6/reactor-unit-reactor-core.assy
+++ b/hardware/v6/reactor-unit-reactor-core.assy
@@ -56,7 +56,6 @@ links:
   - part: reactor-core-inner-jar
     name: inner-jar
     connect:
-      toInstance: bottom
       name: inner-jar-band
 
   - part: reactor-core-outer-jar-band
@@ -69,8 +68,6 @@ links:
   - part: reactor-core-outer-jar
     name: outer-jar
     connect:
-      withInstance: top
-      toInstance: bottom
       name: outer-jar-band
 
   - part: stand-jar-flange

--- a/hardware/v6/reactor-unit-reactor-core.assy
+++ b/hardware/v6/reactor-unit-reactor-core.assy
@@ -1,0 +1,86 @@
+links:
+  - part: reactor-core-inner-jar-band
+    name: inner-jar-band
+
+  - part: reactor-core-manifold-core
+    name: manifold-core
+    connect:
+      withInstance: base
+      toInstance: lid-place
+      name: inner-jar-band
+        
+  - part: reactor-core-manifold-lid
+    name: manifold-lid
+    connect:
+      # TODO: attention, there is a gap between parts for other 2 holes,
+      # we might need to properly take this into account
+      withInstance: back-inner
+      toInstance: side-back
+      name: manifold-core
+  
+  {% for side in ['back', 'left', 'right'] %}
+    # TODO: parameterize screw type
+  - part: /pub/std/metric/cqwarehouse:fastener/raisedcheesehead-iso7045
+    name: {{ side }}-screw-manifold-lid
+    params:
+      size: M3-0.5
+      length: 12
+    connect:
+      toInstance: {{ side }}-outer
+      name: manifold-lid
+  {% endfor %}
+
+  - part: reactor-core-stir-rod-mount
+    name: stir-rod-mount
+    connect:
+      # TODO: there is a small offset (see bottom view),
+      # this needs to be handled
+      withInstance: bottom-back
+      toInstance: top-back
+      name: manifold-core
+  
+  {% for side in ['back', 'left', 'right'] %}
+    # TODO: parameterize screw type
+  - part: /pub/std/metric/cqwarehouse:fastener/raisedcheesehead-iso7045
+    name: {{ side }}-screw-stir-rod-mount
+    params:
+      size: M3-0.5
+      length: 20
+    connect:
+      toInstance: upper-{{ side }}
+      name: stir-rod-mount
+  {% endfor %}
+
+  # TODO: motor, coupler, stirring rod (most probably another assembly)
+
+  - part: reactor-core-inner-jar
+    name: inner-jar
+    connect:
+      toInstance: bottom
+      name: inner-jar-band
+
+  - part: reactor-core-outer-jar-band
+    name: outer-jar-band
+    connect:
+      withInstance: lid-place
+      toInstance: top
+      name: manifold-lid
+
+  - part: reactor-core-outer-jar
+    name: outer-jar
+    connect:
+      withInstance: top
+      toInstance: bottom
+      name: outer-jar-band
+
+  - part: stand-jar-flange
+    name: lower-jar-flange
+    connect:
+      toInstance: neck-lower
+      name: outer-jar
+  
+  - part: stand-jar-flange
+    name: upper-jar-flange
+    connect:
+      toInstance: neck-upper
+      name: outer-jar

--- a/hardware/v6/reactor-unit-reactor-stand.assy
+++ b/hardware/v6/reactor-unit-reactor-stand.assy
@@ -1,3 +1,4 @@
+# TODO: there are also screws but holes are not yet in the models
 links:
   - part: stand-part-h
     name: part-h

--- a/hardware/v6/reactor-unit.assy
+++ b/hardware/v6/reactor-unit.assy
@@ -1,67 +1,16 @@
 links:
-  - part: pumps-box
-    name: box
-
-  # TODO: attaching female barrel plug connectors to box
+  - assembly: reactor-unit-reactor-stand
+    name: reactor-stand
   
-  # Attaching peristaltic pumps to box
-  {% for pump in ['pump-x', 'pump-y', 'pump-z'] %}
-  - part: peristaltic-pump
-    name: {{ pump }}
-    connect:
-      withInstance: lower-left-back
-      toInstance: {{ pump }}-upper-left
-      name: box
-
-  # TODO: add nuts here (now - only screws)
-  {% for corner in ['lower-left-front', 'upper-left-front', 'upper-right-front', 'lower-right-front'] %}
-  - part: /pub/std/metric/cqwarehouse:fastener/{{ param_screw_type }}
-    params:
-      size: M3-0.5
-      length: 16
-    connect:
-      toInstance: {{ corner }}
-      name: {{ pump }}
-  {% endfor %}
-  {% endfor %}
-
-  # Attaching circulation pumps to box
-  # TODO: "elaborate" on proper mounting
-  - part: circulation-pump
-    name: cool-pump
-    connect:
-      toInstance: cool-pump-opening
-      withParams:
-        turnZ: 90
-      name: box
-
-  - part: circulation-pump
-    name: heat-pump
-    connect:
-      toInstance: heat-pump-opening
-      withParams:
-        turnZ: 90
-      name: box
-
-  # TODO: attach connectors to lid
-
-  # Attaching lid to box
-  - part: pumps-box-lid
-    name: lid
-    connect:
-      withInstance: upper-left-front
-      toInstance: upper-left
-      withParams:
-        # TODO: drop turnZ when two-port match is supported (???)
-        turnZ: 90      
-      name: box
+  - assembly: reactor-unit-pumps-box
+    name: pumps-box
+    # TODO: Attention, minor vertical discrepancy 
+    # with -reactor-stand mounts
+    # TODO: rework using interface(s)
+    location: [[4, 96, 132.5], [1, 0, 0], 0]
   
-  {% for corner in ['lower-left', 'upper-left', 'upper-right', 'lower-right'] %}
-  - part: /pub/std/metric/cqwarehouse:fastener/{{ param_screw_type }}
-    params:
-      size: M3-0.5
-      length: 30
+  - assembly: reactor-unit-reactor-core
+    name: reactor-core
     connect:
-      toInstance: {{ corner }}-back
-      name: lid
-  {% endfor %}
+      toInstance: core-holder
+      name: reactor-stand


### PR DESCRIPTION
## TL;DR
Hardware/PartCAD content: added most of the remaining parts of Reactor Unit (without stirring mechanism)

## What
What is affected by this PR?
- [ ] API
- [ ] GUI
- [ ] Hardware Integration
- [ ] OS/Deployment
- [ ] Documentation
- [X] Other (please describe in notes)

## Testing
How was this tested?
- [ ] Locally Virtualized
- [ ] Raspberry Pi
- [ ] With Hardware
- [X] Other (please describe in notes)

## Notes
Tested by rendering 3D assembly and separate sub-assemblies on the local machine